### PR TITLE
Fetch usage value from correct API endpoint

### DIFF
--- a/savio-check_usage/check_usage_coldfront.py
+++ b/savio-check_usage/check_usage_coldfront.py
@@ -258,17 +258,12 @@ def process_account_query():
     allocation = int(float(allocation))
 
     if 'ac_' in account or 'co_' in account:
-        # get usage from history
-        account_usage_url = allocation_url + '{}/history/'.format(allocation_attribute_id)
-        response = single_request(account_usage_url, None)
-        if not response or len(response) == 0:
-            if DEBUG:
-                print('[process_account_query()] ERR')
-
+        # get usage from allocation attribute
+        try:
+            account_usage = response[0]['usage']['value']
+        except KeyError as e:
             raise urllib2.URLError('Backend Error, contact BRC Support (brc-hpc-help@berkeley.edu).')
-
-        account_usage = response[0]['value']
-        job_count, cpu_usage = 0, 0.0
+        job_count, cpu_usage, _ = get_cpu_usage(account=account)
     else:
         # get usage from jobs
         job_count, cpu_usage, account_usage = get_cpu_usage(account=account)


### PR DESCRIPTION
**Changes**
- Modified the handling for `ac_` and `co_` projects to fetch the usage value from the `/api/allocations/{id}/attributes/` endpoint rather than the `/api/allocations/{id}/history/` endpoint, which doesn't provide it.
- Additionally fetched job counts and CPU hours for these projects based on the computed start date.