### PR TITLE
Stop Rendering of Projects User is Removed From

### DIFF
--- a/savio-check_usage/check_usage_coldfront.py
+++ b/savio-check_usage/check_usage_coldfront.py
@@ -39,8 +39,8 @@ SUPPORT_EMAIL = 'brc-hpc-help@berkeley.edu' if MODE == MODE_MYBRC else 'hpcshelp
 timestamp_format_complete = '%Y-%m-%dT%H:%M:%S'
 timestamp_format_minimal = '%Y-%m-%d'
 
-# BASE_URL = 'https://{}/api/'.format('mybrc.brc.berkeley.edu' if MODE == MODE_MYBRC else 'mylrc.lbl.gov')
-BASE_URL = 'http://localhost:8880/api/'
+BASE_URL = 'https://{}/api/'.format('mybrc.brc.berkeley.edu' if MODE == MODE_MYBRC else 'mylrc.lbl.gov')
+# BASE_URL = 'http://localhost:8880/api/'
 ALLOCATION_ENDPOINT = BASE_URL + 'allocations/'
 ALLOCATION_USERS_ENDPOINT = BASE_URL + 'allocation_users/'
 JOB_ENDPOINT = BASE_URL + 'jobs/'

--- a/savio-check_usage/check_usage_coldfront.py
+++ b/savio-check_usage/check_usage_coldfront.py
@@ -284,12 +284,13 @@ def process_user_query(args, output_headers):
         response = paginate_requests(ALLOCATION_USERS_ENDPOINT, {'user': args["user"]})
 
         for allocation in response:
-            allocation_account = allocation['project']
-            allocation_jobs, allocation_cpu, allocation_usage = get_cpu_usage(args, user=args["user"], account=allocation_account)
+            if allocation['status'] != 'Removed':
+                allocation_account = allocation['project']
+                allocation_jobs, allocation_cpu, allocation_usage = get_cpu_usage(args, user=args["user"], account=allocation_account)
 
-            print('\tUsage for USER {} in ACCOUNT {} [{}, {}]: {} jobs, {:.2f} CPUHrs, {} SUs.'
-                  .format(args["user"], allocation_account, to_timestring(args["start"]), 
-                          to_timestring(args["end"]), allocation_jobs, allocation_cpu, allocation_usage))
+                print('\tUsage for USER {} in ACCOUNT {} [{}, {}]: {} jobs, {:.2f} CPUHrs, {} SUs.'
+                    .format(args["user"], allocation_account, to_timestring(args["start"]), 
+                            to_timestring(args["end"]), allocation_jobs, allocation_cpu, allocation_usage))
 
 # Processes an account query to retrieve and display CPU usage statistics.
 def process_account_query(args, output_headers):


### PR DESCRIPTION
Users can be removed from projects in the UI, at which point their `ProjectUser` object gets the status “Removed”. For a given user, `check_usage` should not render projects/accounts that they user has been removed from. The API endpoint the script hits returns the status of the `ProjectUser`, so we use that information to skip rendering the projects the user has been removed from.