### PR TITLE
Check Usage Issue: Stop rendering removed projects

### DIFF
--- a/savio-check_usage/check_usage_coldfront.py
+++ b/savio-check_usage/check_usage_coldfront.py
@@ -398,11 +398,12 @@ def process_user_query():
         response = paginate_requests(user_allocation_url, {'user': user})
 
         for allocation in response:
-            allocation_account = allocation['project']
-            allocation_jobs, allocation_cpu, allocation_usage = get_cpu_usage(user, allocation_account)
+            if allocation['status'] != 'Removed':
+                allocation_account = allocation['project']
+                allocation_jobs, allocation_cpu, allocation_usage = get_cpu_usage(user, allocation_account)
 
-            print('\tUsage for USER {} in ACCOUNT {} [{}, {}]: {} jobs, {:.2f} CPUHrs, {} SUs.'
-                  .format(user, allocation_account, _start, _end, allocation_jobs, allocation_cpu, allocation_usage))
+                print('\tUsage for USER {} in ACCOUNT {} [{}, {}]: {} jobs, {:.2f} CPUHrs, {} SUs.'
+                    .format(user, allocation_account, _start, _end, allocation_jobs, allocation_cpu, allocation_usage))
 
 
 for req_type in output_headers.keys():

--- a/savio-check_usage/check_usage_coldfront.py
+++ b/savio-check_usage/check_usage_coldfront.py
@@ -398,12 +398,15 @@ def process_user_query():
         response = paginate_requests(user_allocation_url, {'user': user})
 
         for allocation in response:
-            if allocation['status'] != 'Removed':
-                allocation_account = allocation['project']
-                allocation_jobs, allocation_cpu, allocation_usage = get_cpu_usage(user, allocation_account)
-
-                print('\tUsage for USER {} in ACCOUNT {} [{}, {}]: {} jobs, {:.2f} CPUHrs, {} SUs.'
-                    .format(user, allocation_account, _start, _end, allocation_jobs, allocation_cpu, allocation_usage))
+            allocation_account = allocation['project']
+            allocation_jobs, allocation_cpu, allocation_usage = get_cpu_usage(user, allocation_account)
+            prefix = '\t'
+            if allocation['status'] == 'Removed':
+                prefix += '(User removed from account) '
+            message = prefix + (
+                'Usage for USER {} in ACCOUNT {} [{}, {}]: {} jobs, {:.2f} CPUHrs, {} SUs.'.format(
+                    user, allocation_account, _start, _end, allocation_jobs, allocation_cpu, allocation_usage))
+            print(message)
 
 
 for req_type in output_headers.keys():


### PR DESCRIPTION
Users can be removed from projects in the UI, at which point their `ProjectUser` object gets the status “Removed”. For a given user, `check_usage` should not render projects/accounts that they user has been removed from. The API endpoint the script hits returns the status of the `ProjectUser`, so we use that information to skip rendering the projects the user has been removed from.